### PR TITLE
modules.ini: add CV32E40P RISC-V CPU

### DIFF
--- a/modules.ini
+++ b/modules.ini
@@ -85,6 +85,14 @@ contents = verilog
 license = License :: ISC License
 license_spdx = ISC
 
+[cv32e40p]
+type = cpu
+human_name = CV32E40P
+src = https://github.com/antmicro/cv32e40p
+contents = system_verilog
+license = License :: OSI Approved :: Apache Software License
+license_spdx = Apache-2.0
+
 # Misc modules
 # ------------------------------
 [compiler_rt]


### PR DESCRIPTION
This adds entry for the CV32E40P RISC-V CPU.
After generating new repository it will also be needed to fix the submodules because some of the sources used by the CPU are located there.