### PR TITLE
Add marocchino OpenRISC cpu

### DIFF
--- a/modules.ini
+++ b/modules.ini
@@ -48,6 +48,15 @@ contents = verilog
 license = License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
 license_spdx = MPL-2.0
 
+[marocchino]
+type = cpu
+human_name = Marocchino
+src = https://github.com/openrisc/or1k_marocchino.git
+contents = verilog
+#license = Open Hardware Description License Version 1.0
+license = License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+license_spdx = MPL-2.0
+
 [picorv32]
 type = cpu
 human_name = PicoRV32


### PR DESCRIPTION
I would like to integrate marocchino into litex.  Adding this data module will help.  The marocchino CPU offers a superscalar architecture and more advanced floating point support (For example 64-bit doubles).