### PR TITLE
Disable interpolation to fix errors on '%'

### DIFF
--- a/update.py
+++ b/update.py
@@ -597,7 +597,7 @@ def main(name, argv):
     tool_version_tuple = version_tuple(tool_version_vdesc)
     tool_version = str(tool_version_vdesc)
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read('modules.ini')
     for module in config.sections():
         if argv and module not in argv:


### PR DESCRIPTION
Items in config-parser can use '%(foo)s' for basic templating.
Sadly, this means that any '%' needs escaping and any '%' in
a git commit will cause the script to fail.

Disable interpolation so we can use '%' without escaping.

Fixes #20, #22