### PR TITLE
Update CV32E40P to be based on the OpenHW Group's repo

### DIFF
--- a/modules.ini
+++ b/modules.ini
@@ -16,10 +16,10 @@ submodule = False
 [cv32e40p]
 type = cpu
 human_name = CV32E40P
-src = https://github.com/antmicro/cv32e40p
+src = https://github.com/openhwgroup/cv32e40p
 contents = system_verilog
 license = License :: OSI Approved :: Apache Software License
-license_spdx = Apache-2.0
+license_spdx = SHL-0.51
 
 [cv32e40x]
 type = cpu


### PR DESCRIPTION
This pull request update the CV32E40P core to be based on the original OpenHW Group's repository ([link](https://github.com/openhwgroup/cv32e40p)).  Is it okay to specify the license as `License :: OSI Approved :: Apache Software License`? Actually, the license should be Solderpad Hardware License v0.51 as indicated in the `license_spdx` field. However, it is not OSI-approved, as mentioned in this [link](http://solderpad.org/licenses/SHL-0.51/) so I'm not sure what to put in the `license` field.
