### PR TITLE
Add support for the Sentinel RISC-V CPU.

### DIFF
--- a/modules.ini
+++ b/modules.ini
@@ -171,6 +171,15 @@ gen_src = https://github.com/SpinalHDL/VexRISCV.git
 git_describe = v1.0.1-265-g5f0c7a7
 git_hash = 5f0c7a7faf6b65c907a93be6e3723e297d37ee71
 
+[sentinel]
+type = cpu
+human_name = Sentinel
+src = https://github.com/cr1901/sentinel
+branch = main
+contents = sources
+license = License :: OSI Approved :: BSD License
+license_spdx = BSD-2-Clause
+
 # Misc modules
 # ------------------------------
 #[compiler_rt]


### PR DESCRIPTION
I have Sentinel working with LiteX [locally](https://github.com/enjoy-digital/litex/compare/master...cr1901:litex:sentinel). Is it possible for someone to set up a `pythondata-cpu-sentinel` repo so that I can merge support into LiteX proper?